### PR TITLE
Disable predictions from gabbar for osmcha-django-production

### DIFF
--- a/osmcha/changeset.py
+++ b/osmcha/changeset.py
@@ -202,7 +202,7 @@ class Analyse(object):
         self.calc_user_score()
         self.calc_changeset_score()
         self.verify_words()
-        self.prediction_from_gabbar()
+        # self.prediction_from_gabbar()
 
     def set_user_score(self, score, reason):
         self.user_score = self.user_score + score


### PR DESCRIPTION
`gabbar` is currently flagging `50%` of the total changesets on osmcha as harmful. This is creating a lot of noise on `osmcha-django-production`.

---

cc: @rodowi @batpad @geohacker 